### PR TITLE
Feature/custom sht30 driver

### DIFF
--- a/smart_ac_controller_main_code/SHT30Driver.cpp
+++ b/smart_ac_controller_main_code/SHT30Driver.cpp
@@ -1,0 +1,78 @@
+#include "SHT30Driver.h"
+
+bool SHT30::begin(const uint8_t i2c_address){
+    m_i2c_address = i2c_address;
+    // Separate the SOFT RESET command into MSB and LSB.
+    const uint8_t soft_reset_msb{static_cast<uint8_t>(SOFT_RESET >> 8)};
+    const uint8_t soft_reset_lsb{static_cast<uint8_t>(SOFT_RESET & 0xFF)};
+    Wire.beginTransmission(i2c_address);
+    Wire.write(soft_reset_msb);
+    Wire.write(soft_reset_lsb);
+    return Wire.endTransmission() ? false : true;
+}
+
+float SHT30::convertTemperatureReadingToCelsius(const uint16_t temperature) {
+    return TEMP_OFFSET + TEMP_SCALAR *temperature / ADC_MAX_VALUE;
+}
+
+float SHT30::convertHumidityReadingToRH(const uint16_t humidity) {
+    return HUMIDITY_OFFSET * humidity / ADC_MAX_VALUE;
+}
+
+bool SHT30::validateChecksum(uint8_t msb, uint8_t lsb, uint8_t received_checksum) {
+    uint8_t crc{CHECKSUM_INITIALIZATION};
+    uint8_t bytes[2]{msb, lsb};
+    for (uint8_t byte : bytes) {
+        crc ^= byte;
+        for (int i = 0; i < 8; i++) {
+            bool isOne{(crc & 0x80) != 0};
+            crc <<= 1;
+            if(isOne) {
+                crc ^= CHECKSUM_POLYNOMIAL;
+            }
+        }
+    }
+    return crc == received_checksum;
+}
+
+SHT30Reading SHT30::readTemperatureAndHumidity(){
+    // Perform Measurement
+    const uint8_t perform_measurement_msb{static_cast<uint8_t>(PERFORM_MEASUREMENT_COMMAND >> 8)};
+    const uint8_t perform_measurement_lsb{static_cast<uint8_t>(PERFORM_MEASUREMENT_COMMAND & 0xFF)};
+    Wire.beginTransmission(m_i2c_address);
+    Wire.write(perform_measurement_msb);
+    Wire.write(perform_measurement_lsb);
+    Wire.endTransmission();
+
+    const uint8_t read_bytes{Wire.requestFrom(m_i2c_address, SENSOR_READING_BYTE_COUNT)};
+    if ( read_bytes != SENSOR_READING_BYTE_COUNT) {
+        return {NAN, NAN};
+    }
+
+    // Read Result
+    const uint8_t temperature_msb{Wire.read()};
+    const uint8_t temperature_lsb{Wire.read()};
+    const uint8_t temperature_crc{Wire.read()};
+    const uint8_t humidity_msb{Wire.read()};
+    const uint8_t humidity_lsb{Wire.read()};
+    const uint8_t humidity_crc{Wire.read()};
+
+    // Checksum Verification
+    if (!validateChecksum(temperature_msb, temperature_lsb, temperature_crc) ||
+        !validateChecksum(humidity_msb, humidity_lsb, humidity_crc)) {
+        return {NAN, NAN};
+    } 
+
+    // Parse Result
+    uint16_t temperature{static_cast<uint16_t>(temperature_msb)<<8};
+    temperature |= temperature_lsb;
+
+    uint16_t humidity{static_cast<uint16_t>(humidity_msb)<<8};
+    humidity |= humidity_lsb;
+
+    // Convert to Celsius and RH
+    float temperature_celsius{convertTemperatureReadingToCelsius(temperature)};
+    float relative_humidity{convertHumidityReadingToRH(humidity)};
+
+    return {temperature_celsius, relative_humidity};
+}

--- a/smart_ac_controller_main_code/SHT30Driver.h
+++ b/smart_ac_controller_main_code/SHT30Driver.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <cstdint>
+#include <Wire.h>
+#include <cmath>
+
+struct SHT30Reading {
+    float temperature;
+    float humidity;
+};
+
+class SHT30 {
+private:
+    // Sensor I2C address.
+    uint8_t m_i2c_address;
+    // Sensor Commands
+    static constexpr uint16_t SOFT_RESET{0x30A2};
+    static constexpr uint16_t PERFORM_MEASUREMENT_COMMAND{0x2C06};
+    static constexpr uint8_t SENSOR_READING_BYTE_COUNT{6};
+
+    // Reading Parsing
+    static constexpr float TEMP_SCALAR{175.0f};
+    static constexpr float TEMP_OFFSET{-45.0f};
+    static constexpr float ADC_MAX_VALUE{65535.0f};
+    static constexpr float HUMIDITY_OFFSET{100.0f};
+
+    float convertTemperatureReadingToCelsius(const uint16_t temperature);
+    float convertHumidityReadingToRH(const uint16_t humidity);
+
+    // CRC CheckSum
+    static constexpr uint8_t CHECKSUM_POLYNOMIAL{0x31};
+    static constexpr uint8_t CHECKSUM_INITIALIZATION{0xFF};
+    bool validateChecksum(uint8_t msb, uint8_t lsb, uint8_t crc);
+public:
+    bool begin(const uint8_t I2C_Address);
+    SHT30Reading readTemperatureAndHumidity();
+};

--- a/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
+++ b/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
@@ -12,17 +12,17 @@
 #include <AsyncTCP.h>
 #include "secrets.h"
 #include <Wire.h>
-#include "Adafruit_SHT31.h"
+#include "SHT30Driver.h"
 
 
 // ============================
 // Constants
 // ============================
 
-// SHT31
+// SHT30
 #define SDA_PIN 22
 #define SCL_PIN 23
-const uint8_t DEFAULT_I2C_ADDRESS{0x44};
+constexpr uint8_t DEFAULT_I2C_ADDRESS{0x44};
 // IR LED
 #define IR_LED_PIN 13
 #define DEFAULT_TEMP 24
@@ -68,7 +68,7 @@ ActiveAutomation automation = {Off, 0, 0, 0};
 // Globals
 // ============================
 IRLgAc ac(IR_LED_PIN);
-Adafruit_SHT31 sht31 = Adafruit_SHT31();
+SHT30 sht30{};
 
 float roomTemperature;
 float humidity;
@@ -94,7 +94,7 @@ void startMDNS();
 void initLittleFS();
 void initIR();
 void initWebServer();
-void initSHT31();
+void initSHT30();
 void toggleACPower();
 void turnOnAC();
 void turnOffAC();
@@ -116,7 +116,7 @@ void setup() {
     startMDNS();
     initIR();
     initWebServer();
-    initSHT31();
+    initSHT30();
 
     Serial.println("Setup complete. Server running!");
 }
@@ -125,8 +125,9 @@ void setup() {
 // Main Loop
 // ============================
 void loop() {
-    roomTemperature = sht31.readTemperature();
-    humidity = sht31.readHumidity();
+    SHT30Reading readingResult{sht30.readTemperatureAndHumidity()};
+    roomTemperature = readingResult.temperature;
+    humidity = readingResult.humidity;
     if(!isnan(roomTemperature)&&!isnan(humidity)) {
         Serial.printf("Room Temperature: %.0f, Humidity: %.0f%%\n", roomTemperature, humidity);
         sendTempAndHumidityToClients();
@@ -183,13 +184,13 @@ void initIR() {
     Serial.println("IR Sender initialized");
 }
 
-void initSHT31() {
+void initSHT30() {
     Wire.begin(SDA_PIN, SCL_PIN);
-    if(!sht31.begin(DEFAULT_I2C_ADDRESS)) {
-        Serial.println("Couldn't find SHT31");
+    if(!sht30.begin(DEFAULT_I2C_ADDRESS)) {
+        Serial.println("Couldn't find SHT30");
         return;
     }
-    Serial.println("SHT31 up.");
+    Serial.println("SHT30 up.");
 }
 
 void sendStateToClients() {

--- a/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
+++ b/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
@@ -22,7 +22,7 @@
 // SHT31
 #define SDA_PIN 22
 #define SCL_PIN 23
-#define DEFAULT_I2C_ADDRESS 0x44
+const uint8_t DEFAULT_I2C_ADDRESS{0x44};
 // IR LED
 #define IR_LED_PIN 13
 #define DEFAULT_TEMP 24
@@ -187,7 +187,6 @@ void initSHT31() {
     Wire.begin(SDA_PIN, SCL_PIN);
     if(!sht31.begin(DEFAULT_I2C_ADDRESS)) {
         Serial.println("Couldn't find SHT31");
-        // maybe we can handle different logic.
         return;
     }
     Serial.println("SHT31 up.");


### PR DESCRIPTION
## Migrate from Adafruit SHT31 Driver to Custom Lightweight SHT30 Driver
### feat: implement sht30 driver
- created a custom sht30 driver with crc checksum validation.
- added begin function for initialization.
- added read function to read from sensor.
- added result parsing functions to convert from uint16_t to float.
- added crc checksum verification.
- created both .cpp and .h files for driver declerations and definitions.
- introduced static constexpr constants for computation on compile, increasing performance.

### refactor: change i2c add macro to uint8_t with uniform initialization
- changed the global i2c sensor address from a macro to a `constexpr uint8_t`

### refactor(sht30): replace adafruit sht30 driver with custom driver in main code