### PR TITLE
Feature/custom i2c wrapper

### DIFF
--- a/smart_ac_controller_main_code/I2CDriver.cpp
+++ b/smart_ac_controller_main_code/I2CDriver.cpp
@@ -1,6 +1,10 @@
 #include "I2CDriver.h"
 
-
+/*
+    Creates a configuration container for the FreeRTOS,
+    configuring the SDA and SCL pins, Mode(Master) and Clock speed,
+    installs the driver
+*/
 bool I2CDriver::begin(const uint8_t sda_pin, const uint8_t scl_pin) {
     m_sda_pin = sda_pin;
     m_scl_pin = scl_pin;
@@ -60,6 +64,32 @@ bool I2CDriver::beginTransmission(uint8_t i2c_address) {
 }
 
 /*
+    Adds a stop signal and passes the entire command link
+    queue to the i2c hardware engine. checks for ack and 
+    deletes the queue.
+*/
+bool I2CDriver::endTransmission() {
+    // Safety Check
+    if (m_command_link_queue == nullptr) {
+        return false;
+    }
+
+    // Queue the STOP Condition
+    i2c_master_stop(m_command_link_queue);
+
+    // Execute the Queue
+    esp_err_t queueExecutionResult = i2c_master_cmd_begin(I2C_NUM_0,
+        m_command_link_queue, pdMS_TO_TICKS(1000));
+
+    // Free the Memory
+    i2c_cmd_link_delete(m_command_link_queue);
+    m_command_link_queue = nullptr;
+
+    // Return status
+    return queueExecutionResult == ESP_OK;
+}
+
+/*
     Enqueues a given byte into the command link queue
 */
 bool I2CDriver::write(const uint8_t data) {
@@ -74,4 +104,5 @@ bool I2CDriver::write(const uint8_t data) {
     // Return Status
     return true;
 }
+
 

--- a/smart_ac_controller_main_code/I2CDriver.cpp
+++ b/smart_ac_controller_main_code/I2CDriver.cpp
@@ -30,26 +30,48 @@ bool I2CDriver::begin(const uint8_t sda_pin, const uint8_t scl_pin) {
     return true;
 }
 
+/*
+    Creates an ESP-IDF I2C command link queue in memory.
+    Queues the I2C START condition and the target device address,
+    instructing the hardware to wait for an ACK from the slave
+    when the transmission is eventually executed.
+*/
 bool I2CDriver::beginTransmission(uint8_t i2c_address) {
     // Create the Command Queue
-    m_command_queue = i2c_cmd_link_create();
+    m_command_link_queue = i2c_cmd_link_create();
 
     // Verify Memory Allocation
-    if (m_command_queue == nullptr) {
+    if (m_command_link_queue == nullptr) {
         return false;
     }
 
     // Queue the START Condition
-    i2c_master_start(m_command_queue);
+    i2c_master_start(m_command_link_queue);
 
     // Prepare the Address Byte
     i2c_address <<= 1;
     i2c_address |= I2C_MASTER_WRITE;
 
     // Queue the Address Byte
-    i2c_master_write_byte(m_command_queue, i2c_address, ACK_CHECK_EN);
+    i2c_master_write_byte(m_command_link_queue, i2c_address, ACK_CHECK_EN);
 
     // Return Success
+    return true;
+}
+
+/*
+    Enqueues a given byte into the command link queue
+*/
+bool I2CDriver::write(const uint8_t data) {
+    // Safety Check
+    if (m_command_link_queue == nullptr) {
+        return false;
+    }
+
+    // Queue the Data Byte
+    i2c_master_write_byte(m_command_link_queue, data, ACK_CHECK_EN);
+
+    // Return Status
     return true;
 }
 

--- a/smart_ac_controller_main_code/I2CDriver.cpp
+++ b/smart_ac_controller_main_code/I2CDriver.cpp
@@ -1,5 +1,5 @@
 #include "I2CDriver.h"
-#include "driver/i2c.h"
+
 
 bool I2CDriver::begin(const uint8_t sda_pin, const uint8_t scl_pin) {
     m_sda_pin = sda_pin;
@@ -30,8 +30,26 @@ bool I2CDriver::begin(const uint8_t sda_pin, const uint8_t scl_pin) {
     return true;
 }
 
-bool I2CDriver::beginTransmission(const uint8_t i2c_address) {
+bool I2CDriver::beginTransmission(uint8_t i2c_address) {
+    // Create the Command Queue
+    m_command_queue = i2c_cmd_link_create();
 
+    // Verify Memory Allocation
+    if (m_command_queue == nullptr) {
+        return false;
+    }
+
+    // Queue the START Condition
+    i2c_master_start(m_command_queue);
+
+    // Prepare the Address Byte
+    i2c_address <<= 1;
+    i2c_address |= I2C_MASTER_WRITE;
+
+    // Queue the Address Byte
+    i2c_master_write_byte(m_command_queue, i2c_address, ACK_CHECK_EN);
+
+    // Return Success
     return true;
 }
 

--- a/smart_ac_controller_main_code/I2CDriver.cpp
+++ b/smart_ac_controller_main_code/I2CDriver.cpp
@@ -105,4 +105,69 @@ bool I2CDriver::write(const uint8_t data) {
     return true;
 }
 
+/*
+    Insert a READ command into the command link queue.
+*/
+uint8_t I2CDriver::read() {
+    // TODO: Implement read function
+    return 0;
+}
 
+
+uint8_t I2CDriver::requestFrom(uint8_t i2c_address, uint8_t quantity) {
+    // Reset Input Buffer
+    m_read_bytes_received = 0;
+    m_read_buffer_index = 0;
+
+    // Cap quantity at buffer size
+    if (quantity > READ_BUFFER_SIZE) {
+        quantity = READ_BUFFER_SIZE;
+    }
+
+    // Handling reading 0 bytes early.
+    if (quantity == 0) {
+        return 0;
+    }
+
+    // Create local command link queue
+    i2c_cmd_handle_t local_cmd_link_queue{i2c_cmd_link_create()};
+    if (local_cmd_link_queue == nullptr) {
+        return 0;
+    }
+
+    // Queue a START cmd
+    i2c_master_start(local_cmd_link_queue);
+
+    // Prepare i2c address
+    i2c_address <<= 1;
+    i2c_address |= I2C_MASTER_READ;
+
+    // Queue the address with ACK on
+    i2c_master_write_byte(local_cmd_link_queue, i2c_address, ACK_CHECK_EN);
+
+    // Queue READ Commands according to quantity
+    if (quantity > 1) {
+        i2c_master_read(local_cmd_link_queue, m_read_buffer,
+            quantity-1, I2C_MASTER_ACK);
+    }
+    i2c_master_read(local_cmd_link_queue, &m_read_buffer[quantity-1],
+        1, I2C_MASTER_NACK);
+    
+    // Queue STOP command
+    i2c_master_stop(local_cmd_link_queue);
+
+    // Execute the command link queue:
+    esp_err_t queueExecutionResult = i2c_master_cmd_begin(I2C_NUM_0,
+        local_cmd_link_queue, pdMS_TO_TICKS(1000));
+    
+    // Free the memory:
+    i2c_cmd_link_delete(local_cmd_link_queue);
+    local_cmd_link_queue = nullptr; // local variable won't cause a dangling pointer.
+
+    // Verify command queue execution result
+    if (queueExecutionResult == ESP_OK) {
+        m_read_bytes_received = quantity;
+        return quantity;
+    }
+    return 0;
+}

--- a/smart_ac_controller_main_code/I2CDriver.cpp
+++ b/smart_ac_controller_main_code/I2CDriver.cpp
@@ -1,0 +1,37 @@
+#include "I2CDriver.h"
+#include "driver/i2c.h"
+
+bool I2CDriver::begin(const uint8_t sda_pin, const uint8_t scl_pin) {
+    m_sda_pin = sda_pin;
+    m_scl_pin = scl_pin;
+    // Create Configuration Container for ESP-IDF
+    i2c_config_t configurationContainer{};
+    // Assign SDA and SCL pins to Configuration Container fields
+    configurationContainer.sda_io_num = sda_pin;
+    configurationContainer.scl_io_num = scl_pin;
+    // Define the Role (ESP32 is Master)
+    configurationContainer.mode = I2C_MODE_MASTER;
+    // Activate Internal Pull Ups
+    configurationContainer.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    configurationContainer.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    // Set the Clock Frequency
+    configurationContainer.master.clk_speed = 100000;
+    // Apply the Parameters
+    esp_err_t applicationResult = i2c_param_config(I2C_NUM_0, &configurationContainer);
+    if (applicationResult != ESP_OK) {
+        return false;
+    }
+    // Install the Driver
+    esp_err_t installResult = i2c_driver_install(I2C_NUM_0, I2C_MODE_MASTER, 0, 0, 0);
+    if (installResult != ESP_OK) {
+        return false;
+    }
+    // Verify and return.
+    return true;
+}
+
+bool I2CDriver::beginTransmission(const uint8_t i2c_address) {
+
+    return true;
+}
+

--- a/smart_ac_controller_main_code/I2CDriver.cpp
+++ b/smart_ac_controller_main_code/I2CDriver.cpp
@@ -105,15 +105,6 @@ bool I2CDriver::write(const uint8_t data) {
     return true;
 }
 
-/*
-    Insert a READ command into the command link queue.
-*/
-uint8_t I2CDriver::read() {
-    // TODO: Implement read function
-    return 0;
-}
-
-
 uint8_t I2CDriver::requestFrom(uint8_t i2c_address, uint8_t quantity) {
     // Reset Input Buffer
     m_read_bytes_received = 0;
@@ -170,4 +161,23 @@ uint8_t I2CDriver::requestFrom(uint8_t i2c_address, uint8_t quantity) {
         return quantity;
     }
     return 0;
+}
+
+/*
+    Insert a READ command into the command link queue.
+*/
+int I2CDriver::read() {
+    // Check if any bytes left to read
+    if (m_read_buffer_index >= m_read_bytes_received) {
+        return -1;
+    }
+
+    // Grab byte at current index
+    uint8_t byte{m_read_buffer[m_read_buffer_index]};
+
+    // Increase buffer index
+    ++m_read_buffer_index;
+
+    // Return read byte
+    return byte;
 }

--- a/smart_ac_controller_main_code/I2CDriver.h
+++ b/smart_ac_controller_main_code/I2CDriver.h
@@ -1,9 +1,12 @@
 #pragma once
 #include <cstdint>
+#include "driver/i2c.h"
+
 class I2CDriver {
 private:
     uint8_t m_sda_pin;
     uint8_t m_scl_pin;
+    i2c_cmd_handle_t m_command_queue;
 public:
     bool begin(const uint8_t sda_pin, const uint8_t scl_pin);
     bool beginTransmission(const uint8_t i2c_address);

--- a/smart_ac_controller_main_code/I2CDriver.h
+++ b/smart_ac_controller_main_code/I2CDriver.h
@@ -6,12 +6,12 @@ class I2CDriver {
 private:
     uint8_t m_sda_pin;
     uint8_t m_scl_pin;
-    i2c_cmd_handle_t m_command_queue;
+    i2c_cmd_handle_t m_command_link_queue;
 public:
     bool begin(const uint8_t sda_pin, const uint8_t scl_pin);
     bool beginTransmission(const uint8_t i2c_address);
-    void write(const uint8_t data);
     void endTransmission();
+    bool write(const uint8_t data);
     uint8_t read();
     uint8_t requestFrom();
 };

--- a/smart_ac_controller_main_code/I2CDriver.h
+++ b/smart_ac_controller_main_code/I2CDriver.h
@@ -10,7 +10,7 @@ private:
 public:
     bool begin(const uint8_t sda_pin, const uint8_t scl_pin);
     bool beginTransmission(const uint8_t i2c_address);
-    void endTransmission();
+    bool endTransmission();
     bool write(const uint8_t data);
     uint8_t read();
     uint8_t requestFrom();

--- a/smart_ac_controller_main_code/I2CDriver.h
+++ b/smart_ac_controller_main_code/I2CDriver.h
@@ -4,14 +4,22 @@
 
 class I2CDriver {
 private:
-    uint8_t m_sda_pin;
-    uint8_t m_scl_pin;
-    i2c_cmd_handle_t m_command_link_queue;
+    uint8_t m_sda_pin{};
+    uint8_t m_scl_pin{};
+    i2c_cmd_handle_t m_command_link_queue{};
+    static constexpr bool ACK_CHECK_EN{true};
+
+    // Read Buffer
+    static constexpr uint8_t READ_BUFFER_SIZE{32};
+    uint8_t m_read_buffer[READ_BUFFER_SIZE]{};
+    uint8_t m_read_bytes_received{};
+    uint8_t m_read_buffer_index{};
+
 public:
     bool begin(const uint8_t sda_pin, const uint8_t scl_pin);
     bool beginTransmission(const uint8_t i2c_address);
     bool endTransmission();
     bool write(const uint8_t data);
     uint8_t read();
-    uint8_t requestFrom();
+    uint8_t requestFrom(uint8_t i2c_address, uint8_t quantity);
 };

--- a/smart_ac_controller_main_code/I2CDriver.h
+++ b/smart_ac_controller_main_code/I2CDriver.h
@@ -20,6 +20,6 @@ public:
     bool beginTransmission(const uint8_t i2c_address);
     bool endTransmission();
     bool write(const uint8_t data);
-    uint8_t read();
+    int read();
     uint8_t requestFrom(uint8_t i2c_address, uint8_t quantity);
 };

--- a/smart_ac_controller_main_code/I2CDriver.h
+++ b/smart_ac_controller_main_code/I2CDriver.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <cstdint>
+class I2CDriver {
+private:
+    uint8_t m_sda_pin;
+    uint8_t m_scl_pin;
+public:
+    bool begin(const uint8_t sda_pin, const uint8_t scl_pin);
+    bool beginTransmission(const uint8_t i2c_address);
+    void write(const uint8_t data);
+    void endTransmission();
+    uint8_t read();
+    uint8_t requestFrom();
+};

--- a/smart_ac_controller_main_code/SHT30Driver.cpp
+++ b/smart_ac_controller_main_code/SHT30Driver.cpp
@@ -1,14 +1,26 @@
 #include "SHT30Driver.h"
 
+SHT30::SHT30(I2CDriver& i2c_driver) : m_i2c_driver(i2c_driver) {}
+
 bool SHT30::begin(const uint8_t i2c_address){
     m_i2c_address = i2c_address;
     // Separate the SOFT RESET command into MSB and LSB.
     const uint8_t soft_reset_msb{static_cast<uint8_t>(SOFT_RESET >> 8)};
     const uint8_t soft_reset_lsb{static_cast<uint8_t>(SOFT_RESET & 0xFF)};
-    Wire.beginTransmission(i2c_address);
-    Wire.write(soft_reset_msb);
-    Wire.write(soft_reset_lsb);
-    return Wire.endTransmission() ? false : true;
+    
+    // Transmit commands to SHT30 throught the i2c bus
+    m_i2c_driver.beginTransmission(i2c_address);
+    m_i2c_driver.write(soft_reset_msb);
+    m_i2c_driver.write(soft_reset_lsb);
+    const bool transmissionResult{m_i2c_driver.endTransmission()};
+    if(!transmissionResult) {
+        return false;
+    }
+    // Wait for sensor to perform soft reset
+    vTaskDelay(pdMS_TO_TICKS(SOFT_RESET_DELAY_TIME));
+
+    // Return result
+    return true;
 }
 
 float SHT30::convertTemperatureReadingToCelsius(const uint16_t temperature) {
@@ -39,23 +51,27 @@ SHT30Reading SHT30::readTemperatureAndHumidity(){
     // Perform Measurement
     const uint8_t perform_measurement_msb{static_cast<uint8_t>(PERFORM_MEASUREMENT_COMMAND >> 8)};
     const uint8_t perform_measurement_lsb{static_cast<uint8_t>(PERFORM_MEASUREMENT_COMMAND & 0xFF)};
-    Wire.beginTransmission(m_i2c_address);
-    Wire.write(perform_measurement_msb);
-    Wire.write(perform_measurement_lsb);
-    Wire.endTransmission();
+    m_i2c_driver.beginTransmission(m_i2c_address);
+    m_i2c_driver.write(perform_measurement_msb);
+    m_i2c_driver.write(perform_measurement_lsb);
+    const bool transmissionSuccessful{m_i2c_driver.endTransmission()};
+    if (!transmissionSuccessful) {
+        return {NAN, NAN};
+    }
+    // Delay - wait for sensor to perform measurement.
+    vTaskDelay(pdMS_TO_TICKS(MEASUREMENT_DELAY_TIME));
 
-    const uint8_t read_bytes{Wire.requestFrom(m_i2c_address, SENSOR_READING_BYTE_COUNT)};
+    // Read Result
+    const uint8_t read_bytes{m_i2c_driver.requestFrom(m_i2c_address, SENSOR_READING_BYTE_COUNT)};
     if ( read_bytes != SENSOR_READING_BYTE_COUNT) {
         return {NAN, NAN};
     }
-
-    // Read Result
-    const uint8_t temperature_msb{Wire.read()};
-    const uint8_t temperature_lsb{Wire.read()};
-    const uint8_t temperature_crc{Wire.read()};
-    const uint8_t humidity_msb{Wire.read()};
-    const uint8_t humidity_lsb{Wire.read()};
-    const uint8_t humidity_crc{Wire.read()};
+    const uint8_t temperature_msb{static_cast<uint8_t>(m_i2c_driver.read())};
+    const uint8_t temperature_lsb{static_cast<uint8_t>(m_i2c_driver.read())};
+    const uint8_t temperature_crc{static_cast<uint8_t>(m_i2c_driver.read())};
+    const uint8_t humidity_msb{static_cast<uint8_t>(m_i2c_driver.read())};
+    const uint8_t humidity_lsb{static_cast<uint8_t>(m_i2c_driver.read())};
+    const uint8_t humidity_crc{static_cast<uint8_t>(m_i2c_driver.read())};
 
     // Checksum Verification
     if (!validateChecksum(temperature_msb, temperature_lsb, temperature_crc) ||

--- a/smart_ac_controller_main_code/SHT30Driver.h
+++ b/smart_ac_controller_main_code/SHT30Driver.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <cstdint>
-#include <Wire.h>
 #include <cmath>
+#include "I2CDriver.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 struct SHT30Reading {
     float temperature;
@@ -10,12 +12,20 @@ struct SHT30Reading {
 
 class SHT30 {
 private:
+    // I2C Driver
+    I2CDriver& m_i2c_driver;
+
     // Sensor I2C address.
-    uint8_t m_i2c_address;
+    uint8_t m_i2c_address{};
+
     // Sensor Commands
     static constexpr uint16_t SOFT_RESET{0x30A2};
     static constexpr uint16_t PERFORM_MEASUREMENT_COMMAND{0x2C06};
     static constexpr uint8_t SENSOR_READING_BYTE_COUNT{6};
+
+    // Sensor Delay Times
+    static constexpr uint8_t SOFT_RESET_DELAY_TIME{2};
+    static constexpr uint8_t MEASUREMENT_DELAY_TIME{15};
 
     // Reading Parsing
     static constexpr float TEMP_SCALAR{175.0f};
@@ -31,6 +41,7 @@ private:
     static constexpr uint8_t CHECKSUM_INITIALIZATION{0xFF};
     bool validateChecksum(uint8_t msb, uint8_t lsb, uint8_t crc);
 public:
-    bool begin(const uint8_t I2C_Address);
+    SHT30(I2CDriver& i2c_driver);
+    bool begin(const uint8_t i2c_address);
     SHT30Reading readTemperatureAndHumidity();
 };

--- a/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
+++ b/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
@@ -11,17 +11,20 @@
 #include <ESPAsyncWebServer.h>
 #include <AsyncTCP.h>
 #include "secrets.h"
-#include <Wire.h>
 #include "SHT30Driver.h"
+#include "I2CDriver.h"
 
 
 // ============================
 // Constants
 // ============================
 
+// I2C Driver
+I2CDriver i2c_driver;
+
 // SHT30
-#define SDA_PIN 22
-#define SCL_PIN 23
+constexpr uint8_t SDA_PIN{22};
+constexpr uint8_t SCL_PIN{23};
 constexpr uint8_t DEFAULT_I2C_ADDRESS{0x44};
 // IR LED
 #define IR_LED_PIN 13
@@ -68,7 +71,7 @@ ActiveAutomation automation = {Off, 0, 0, 0};
 // Globals
 // ============================
 IRLgAc ac(IR_LED_PIN);
-SHT30 sht30{};
+SHT30 sht30(i2c_driver);
 
 float roomTemperature;
 float humidity;
@@ -185,7 +188,10 @@ void initIR() {
 }
 
 void initSHT30() {
-    Wire.begin(SDA_PIN, SCL_PIN);
+    if(!i2c_driver.begin(SDA_PIN, SCL_PIN)) {
+        Serial.println("I2C Driver Initialization Failed.");
+        return;
+    }
     if(!sht30.begin(DEFAULT_I2C_ADDRESS)) {
         Serial.println("Couldn't find SHT30");
         return;


### PR DESCRIPTION
## Migrate SHT30 to custom I2C Wrapper

### Summary
Implements a custom I2C wrapper from scratch and migrates the SHT30 temperature/humidity sensor off the Arduino `Wire` library onto it.

### Changes
- **Driver initialization** — configure and bring up the I2C peripheral
- **`beginTransmission`** — start a transaction to a target device
- **`write`** — enqueue data bytes into the command link queue
- **`endTransmission`** — flush the command link queue to the hardware engine to send
- **`requestFrom`** — read from the I2C bus into a buffer
- **Refactor** — migrate SHT30 from `Wire` to the custom driver

### Notes
Replaces the `Wire` dependency for the SHT30 with a self-contained driver built directly on the ESP32 I2C hardware engine and command-link queue.