### PR TITLE
feat(uart): replace Arduino Serial with a custom UART driver

### DIFF
--- a/smart_ac_controller_main_code/UARTDriver.cpp
+++ b/smart_ac_controller_main_code/UARTDriver.cpp
@@ -47,6 +47,9 @@ bool UARTDriver::begin(const uint32_t baud_rate) {
     return true;
 }
 
+/*
+    Writes a given byte array to the UART TX Pin.
+*/
 size_t UARTDriver::write(const uint8_t* data, size_t length) {
     // Check if Driver is initialized, If the pointer is null or length is null return 0
     if (!m_initialized || data == nullptr || length == 0) {
@@ -62,6 +65,41 @@ size_t UARTDriver::write(const uint8_t* data, size_t length) {
     return static_cast<size_t>(write_result);
 }
 
+/*
+    Writes a single byte to the UART TX Pin.
+*/
 size_t UARTDriver::write(const uint8_t byte) {
+    if (!m_initialized) {
+        return 0;
+    }
     return write(&byte, 1);
+}
+
+/*
+    Prints a given c style string to the console 
+*/
+size_t UARTDriver::print(const char* text) {
+    // Check if driver is initialized or pointer is null
+    if (!m_initialized || text == nullptr) {
+        return 0;
+    }
+    // Measure the length
+    size_t text_length{std::strlen(text)};
+    // Write to UART TX pin with write function
+    return write(reinterpret_cast<const uint8_t*>(text), text_length);
+}
+
+/*
+    Prints a given c style string to the console ending
+    with a new line.
+*/
+size_t UARTDriver::println(const char* text) {
+    // Check if driver is initialized or pointer is null
+    if (!m_initialized || text == nullptr) {
+        return 0;
+    }
+    // Utilize print and write
+    size_t text_written_bytes{print(text)};
+    size_t newline_written_bytes{write(NEWLINE_CHAR)};
+    return text_written_bytes + newline_written_bytes;
 }

--- a/smart_ac_controller_main_code/UARTDriver.cpp
+++ b/smart_ac_controller_main_code/UARTDriver.cpp
@@ -28,7 +28,7 @@ bool UARTDriver::begin(const uint32_t baud_rate) {
 
     // apply config
     esp_err_t parameter_application_result = uart_param_config(UART_PORT,
-        & uart_config_struct);
+        &uart_config_struct);
     if (parameter_application_result != ESP_OK) {
         uart_driver_delete(UART_PORT);
         return false;
@@ -47,7 +47,21 @@ bool UARTDriver::begin(const uint32_t baud_rate) {
     return true;
 }
 
-size_t UARTDriver::write(uint8_t byte) {
-    // To be Implemented.
-    return 0;
+size_t UARTDriver::write(const uint8_t* data, size_t length) {
+    // Check if Driver is initialized, If the pointer is null or length is null return 0
+    if (!m_initialized || data == nullptr || length == 0) {
+        return 0;
+    }
+    // Utilize ESP-IDF uart_write_bytes
+    int write_result = uart_write_bytes(UART_PORT, data, length);
+    // Check result
+    if (write_result < 0) {
+        return 0;
+    }
+    // Return result
+    return static_cast<size_t>(write_result);
+}
+
+size_t UARTDriver::write(const uint8_t byte) {
+    return write(&byte, 1);
 }

--- a/smart_ac_controller_main_code/UARTDriver.cpp
+++ b/smart_ac_controller_main_code/UARTDriver.cpp
@@ -1,0 +1,53 @@
+#include "UARTDriver.h"
+
+/*
+    Initializes the serial UART driver using the uart_config_t
+    struct, installs the drivers, applies parameters, sets pins
+    and returns result.
+*/
+bool UARTDriver::begin(const uint32_t baud_rate) {
+    // Store the baud rate
+    m_baud_rate = baud_rate;
+
+    // Create a configuration struct
+    uart_config_t uart_config_struct{};
+    uart_config_struct.baud_rate = baud_rate;
+    uart_config_struct.data_bits = UART_DATA_8_BITS;
+    uart_config_struct.parity = UART_PARITY_DISABLE;
+    uart_config_struct.stop_bits = UART_STOP_BITS_1;
+    uart_config_struct.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+    uart_config_struct.source_clk = UART_SCLK_DEFAULT;
+
+    // install driver
+    esp_err_t driver_installation_result = uart_driver_install(UART_PORT,
+        RX_BUFFER_SIZE, TX_BUFFER_SIZE, QUEUE_SIZE,
+        UART_QUEUE, INTERRUPT_ALLOCATION_FLAGS);
+    if (driver_installation_result != ESP_OK) {
+        return false;
+    }
+
+    // apply config
+    esp_err_t parameter_application_result = uart_param_config(UART_PORT,
+        & uart_config_struct);
+    if (parameter_application_result != ESP_OK) {
+        uart_driver_delete(UART_PORT);
+        return false;
+    }
+
+    // set TX and RX pins
+    esp_err_t set_pin_result = uart_set_pin(UART_PORT,
+        TX_PIN, RX_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    if (set_pin_result != ESP_OK) {
+        uart_driver_delete(UART_PORT);
+        return false;
+    }
+
+    // return result
+    m_initialized = true;
+    return true;
+}
+
+size_t UARTDriver::write(uint8_t byte) {
+    // To be Implemented.
+    return 0;
+}

--- a/smart_ac_controller_main_code/UARTDriver.cpp
+++ b/smart_ac_controller_main_code/UARTDriver.cpp
@@ -1,3 +1,6 @@
+#include <cstring>
+#include <cstdio>
+#include <cstdarg>
 #include "UARTDriver.h"
 
 /*
@@ -6,9 +9,6 @@
     and returns result.
 */
 bool UARTDriver::begin(const uint32_t baud_rate) {
-    // Store the baud rate
-    m_baud_rate = baud_rate;
-
     // Create a configuration struct
     uart_config_t uart_config_struct{};
     uart_config_struct.baud_rate = baud_rate;
@@ -105,7 +105,7 @@ size_t UARTDriver::println(const char* text) {
 }
 
 /*
-
+    Prints formatted strings to the serial console.
 */
 size_t UARTDriver::printf(const char* format, ...) {
     // Check if driver is initialized or pointer is null
@@ -119,7 +119,7 @@ size_t UARTDriver::printf(const char* format, ...) {
     va_list arguments;
     va_start(arguments, format);
     // Create a string with the correct formatting inside the buffer
-    int length = vsnprintf(temporary_buffer, sizeof(temporary_buffer), format, arguments);
+    int length = std::vsnprintf(temporary_buffer, sizeof(temporary_buffer), format, arguments);
     va_end(arguments);
 
     // verify

--- a/smart_ac_controller_main_code/UARTDriver.cpp
+++ b/smart_ac_controller_main_code/UARTDriver.cpp
@@ -103,3 +103,29 @@ size_t UARTDriver::println(const char* text) {
     size_t newline_written_bytes{write(NEWLINE_CHAR)};
     return text_written_bytes + newline_written_bytes;
 }
+
+/*
+
+*/
+size_t UARTDriver::printf(const char* format, ...) {
+    // Check if driver is initialized or pointer is null
+    if (!m_initialized || format == nullptr) {
+        return 0;
+    }
+    // Create a temporary buffer
+    char temporary_buffer[PRINTF_BUFFER_SIZE];
+
+    // utilize va_list, va_start, vsnprintf and va_end
+    va_list arguments;
+    va_start(arguments, format);
+    // Create a string with the correct formatting inside the buffer
+    int length = vsnprintf(temporary_buffer, sizeof(temporary_buffer), format, arguments);
+    va_end(arguments);
+
+    // verify
+    if (length < 0) {
+        return 0;
+    }
+    size_t written_bytes{print(temporary_buffer)};
+    return written_bytes;
+}

--- a/smart_ac_controller_main_code/UARTDriver.h
+++ b/smart_ac_controller_main_code/UARTDriver.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <cstdint>
+#include <cstdarg>
+#include <cstddef>
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "driver/uart.h"
+
+class UARTDriver {
+private:
+    uint32_t m_baud_rate{};
+    bool m_initialized{false};
+    static constexpr uart_port_t UART_PORT{UART_NUM_0};
+    static constexpr int RX_BUFFER_SIZE{256};
+    static constexpr int TX_BUFFER_SIZE{0};
+    static constexpr int QUEUE_SIZE{0};
+    static constexpr QueueHandle_t* UART_QUEUE{nullptr};
+    static constexpr int INTERRUPT_ALLOCATION_FLAGS{0};
+    static constexpr int TX_PIN{1};
+    static constexpr int RX_PIN{3}; 
+public:
+    bool begin(const uint32_t baud_rate);
+    size_t write(uint8_t byte);
+    size_t write(const uint8_t* data, size_t length);
+    size_t print(const char* text);
+    size_t println(const char* text);
+    int printf(const char* format, ...);
+
+    // Optional, currently not needed in the project
+    //void read();
+    //void available();
+    void end();
+    void flush();
+};

--- a/smart_ac_controller_main_code/UARTDriver.h
+++ b/smart_ac_controller_main_code/UARTDriver.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstdarg>
 #include <cstddef>
+#include <cstring>
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "driver/uart.h"
@@ -18,6 +19,7 @@ private:
     static constexpr int INTERRUPT_ALLOCATION_FLAGS{0};
     static constexpr int TX_PIN{1};
     static constexpr int RX_PIN{3}; 
+    static constexpr char NEWLINE_CHAR{'\n'};
 public:
     bool begin(const uint32_t baud_rate);
     size_t write(const uint8_t byte);

--- a/smart_ac_controller_main_code/UARTDriver.h
+++ b/smart_ac_controller_main_code/UARTDriver.h
@@ -20,17 +20,18 @@ private:
     static constexpr int TX_PIN{1};
     static constexpr int RX_PIN{3}; 
     static constexpr char NEWLINE_CHAR{'\n'};
+    static constexpr int PRINTF_BUFFER_SIZE{128};
 public:
     bool begin(const uint32_t baud_rate);
     size_t write(const uint8_t byte);
     size_t write(const uint8_t* data, size_t length);
     size_t print(const char* text);
     size_t println(const char* text);
-    int printf(const char* format, ...);
+    size_t printf(const char* format, ...);
 
     // Optional, currently not needed in the project
     //void read();
     //void available();
-    void end();
-    void flush();
+    //void end();
+    //void flush();
 };

--- a/smart_ac_controller_main_code/UARTDriver.h
+++ b/smart_ac_controller_main_code/UARTDriver.h
@@ -1,15 +1,12 @@
 #pragma once
 #include <cstdint>
-#include <cstdarg>
 #include <cstddef>
-#include <cstring>
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "driver/uart.h"
 
 class UARTDriver {
 private:
-    uint32_t m_baud_rate{};
     bool m_initialized{false};
     static constexpr uart_port_t UART_PORT{UART_NUM_0};
     static constexpr int RX_BUFFER_SIZE{256};

--- a/smart_ac_controller_main_code/UARTDriver.h
+++ b/smart_ac_controller_main_code/UARTDriver.h
@@ -20,7 +20,7 @@ private:
     static constexpr int RX_PIN{3}; 
 public:
     bool begin(const uint32_t baud_rate);
-    size_t write(uint8_t byte);
+    size_t write(const uint8_t byte);
     size_t write(const uint8_t* data, size_t length);
     size_t print(const char* text);
     size_t println(const char* text);

--- a/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
+++ b/smart_ac_controller_main_code/smart_ac_controller_main_code.ino
@@ -13,14 +13,23 @@
 #include "secrets.h"
 #include "SHT30Driver.h"
 #include "I2CDriver.h"
+#include "UARTDriver.h"
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 
 // ============================
 // Constants
 // ============================
 
-// I2C Driver
+// I2C Wrapper
 I2CDriver i2c_driver;
+
+// UART Wrapper (Serial)
+UARTDriver serial;
+constexpr uint32_t SERIAL_BAUD_RATE{115200};
+constexpr gpio_num_t ESP_INTERNAL_LED_PIN{GPIO_NUM_2};
 
 // SHT30
 constexpr uint8_t SDA_PIN{22};
@@ -111,8 +120,17 @@ void setACFan(uint8_t fanMode);
 // Setup
 // ============================
 void setup() {
-    Serial.begin(115200);
-    delay(1000);
+    if(!serial.begin(SERIAL_BAUD_RATE)) {
+        gpio_reset_pin(ESP_INTERNAL_LED_PIN);
+        gpio_set_direction(ESP_INTERNAL_LED_PIN, GPIO_MODE_OUTPUT);
+        for(size_t i = 0; i < 4; ++i) {
+            gpio_set_level(ESP_INTERNAL_LED_PIN, 1);
+            vTaskDelay(pdMS_TO_TICKS(200));
+            gpio_set_level(ESP_INTERNAL_LED_PIN, 0);
+            vTaskDelay(pdMS_TO_TICKS(200));
+        }
+    }
+    vTaskDelay(pdMS_TO_TICKS(1000));
 
     initLittleFS();
     connectToWiFi();
@@ -121,7 +139,7 @@ void setup() {
     initWebServer();
     initSHT30();
 
-    Serial.println("Setup complete. Server running!");
+    serial.println("Setup complete. Server running!");
 }
 
 // ============================
@@ -132,14 +150,14 @@ void loop() {
     roomTemperature = readingResult.temperature;
     humidity = readingResult.humidity;
     if(!isnan(roomTemperature)&&!isnan(humidity)) {
-        Serial.printf("Room Temperature: %.0f, Humidity: %.0f%%\n", roomTemperature, humidity);
+        serial.printf("Room Temperature: %.0f, Humidity: %.0f%%\n", roomTemperature, humidity);
         sendTempAndHumidityToClients();
     } else {
-        Serial.println("Failed to get Room Temperature & Humidity readings.");
+        serial.println("Failed to get Room Temperature & Humidity readings.");
     }
     switch(automation.automationMode) {
         case Temperature:
-            Serial.println("Temperature Automation!");
+            serial.println("Temperature Automation!");
             if(roomTemperature >= automation.roomTempToActivateAutomation) {
                 if(currentTemp != automation.acTempToSetOnActivation || currentMode != automation.acModeToSetOnActivation || !currentPower) {
                     setACTemperature(automation.acTempToSetOnActivation);
@@ -158,45 +176,45 @@ void loop() {
 // Functions
 // ============================
 void connectToWiFi() {
-    Serial.print("Connecting to Wi-Fi...");
+    serial.print("Connecting to Wi-Fi...");
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
     while (WiFi.status() != WL_CONNECTED) {
         delay(500);
-        Serial.print(".");
+        serial.print(".");
     }
-    Serial.println("\nConnected! IP: " + WiFi.localIP().toString());
+    serial.printf("\nConnected! IP: %s\n" ,WiFi.localIP().toString().c_str());
 }
 
 void startMDNS() {
     if (MDNS.begin(SERVER_DOMAIN)) {
-        Serial.println("mDNS responder started");
+        serial.println("mDNS responder started");
     }
 }
 
 void initLittleFS() {
     if (LittleFS.begin(true)) {
-        Serial.println("LittleFS mounted successfully");
+        serial.println("LittleFS mounted successfully");
     } else {
-        Serial.println("LittleFS mount failed");
+        serial.println("LittleFS mount failed");
     }
 }
 
 
 void initIR() {
     ac.begin();
-    Serial.println("IR Sender initialized");
+    serial.println("IR Sender initialized");
 }
 
 void initSHT30() {
     if(!i2c_driver.begin(SDA_PIN, SCL_PIN)) {
-        Serial.println("I2C Driver Initialization Failed.");
+        serial.println("I2C Driver Initialization Failed.");
         return;
     }
     if(!sht30.begin(DEFAULT_I2C_ADDRESS)) {
-        Serial.println("Couldn't find SHT30");
+        serial.println("Couldn't find SHT30");
         return;
     }
-    Serial.println("SHT30 up.");
+    serial.println("SHT30 up.");
 }
 
 void sendStateToClients() {
@@ -351,7 +369,7 @@ void initWebServer() {
     ws.onEvent([](AsyncWebSocket *server, AsyncWebSocketClient *client, 
                   AwsEventType type, void *arg, uint8_t *data, size_t len) {
         if(type == WS_EVT_CONNECT) {
-            Serial.printf("WebSocket client #%u connected\n", client->id());
+            serial.printf("WebSocket client #%u connected\n", client->id());
             sendStateToClients();
         }
     });
@@ -359,7 +377,7 @@ void initWebServer() {
     server.addHandler(&ws);
 
     server.begin();
-    Serial.println("Async web server started!");
+    serial.println("Async web server started!");
 }
 
 void toggleACPower() {
@@ -371,11 +389,11 @@ void toggleACPower() {
     ac.setFan(currentFan);
 
     ac.send();
-    Serial.println("AC power command sent");
+    serial.println("AC power command sent");
 }
 
 void setACTemperature(uint8_t temp) {
-    Serial.printf("Setting AC temperature to %d°C...\n", temp);
+    serial.printf("Setting AC temperature to %d°C...\n", temp);
     currentTemp = temp;
     currentPower = POWER_ON;
     ac.on();
@@ -385,11 +403,11 @@ void setACTemperature(uint8_t temp) {
     ac.setFan(currentFan);
 
     ac.send();
-    Serial.println("AC temperature command sent");
+    serial.println("AC temperature command sent");
 }
 
 void setACFan(uint8_t fanMode) {
-    Serial.printf("Setting AC fan to %d...\n", fanMode);
+    serial.printf("Setting AC fan to %d...\n", fanMode);
     currentFan = fanMode;
     currentPower = POWER_ON;
 
@@ -399,11 +417,11 @@ void setACFan(uint8_t fanMode) {
     ac.setFan(fanMode);
 
     ac.send();
-    Serial.println("AC fan command sent");
+    serial.println("AC fan command sent");
 }
 
 void setACMode(uint8_t mode) {
-    Serial.printf("Setting AC mode to %d...", mode);
+    serial.printf("Setting AC mode to %d...", mode);
     currentMode = mode;
     currentPower = POWER_ON;
     ac.on();
@@ -411,5 +429,5 @@ void setACMode(uint8_t mode) {
     ac.setMode(mode);
     ac.setFan(currentFan);
     ac.send();
-    Serial.println("AC mode command sent");
+    serial.println("AC mode command sent");
 }


### PR DESCRIPTION
Removes the dependency on Arduino's `Serial` object by implementing a
`UARTDriver` class over the ESP-IDF UART API. Continues the effort to
strip Arduino framework dependencies from the project.

## What changed

- **`UARTDriver::begin`** — configures the UART for 8N1 at a caller-supplied
  baud rate, installs the ESP-IDF driver, and routes TX/RX through the GPIO
  matrix. Each failure path unwinds whatever succeeded before it.
- **`write`** — two overloads, one byte and one buffer. The single-byte version
  delegates, so exactly one function touches the peripheral.
- **`print` / `println`** — C-string output, built on `write`.
- **`printf`** — variadic formatting via `vsnprintf` into a fixed 128-byte
  stack buffer. No dynamic allocation.
- **Migration** — all 24 call sites in `smart_ac_controller_main_code.ino`
  moved from `Serial` to the new driver. Both `Serial.begin()` calls removed
  so Arduino never claims UART0.
- `begin()`'s result is now checked; failure blinks the onboard LED via
  `driver/gpio.h`, since reporting a UART failure over UART isn't an option.

## Notes

- Uses `UART_SCLK_APB` rather than `UART_SCLK_DEFAULT`, which requires
  ESP-IDF 5.0. `APB` is valid on both, so this stays portable across the
  planned ESP-IDF migration.
- `TX_BUFFER_SIZE` is 0, making writes blocking. Appropriate for log output
  and simpler to reason about than a background ring buffer.
- `read()`, `available()`, `end()`, and `flush()` are intentionally left
  unimplemented — nothing in the project reads from serial or tears the
  port down.

## Testing

Flashed to an ESP32-D0WD. Boot messages, Wi-Fi connection output, and the
periodic temperature/humidity readings all appear correctly at 115200.

## Follow-ups

Tracked separately: initialization guard for `I2CDriver::requestFrom`,
removal of dead members from `I2CDriver`, explicit FreeRTOS includes, and
a whitespace fix in `UARTDriver.cpp`.